### PR TITLE
Removing oc-full-height reference on admin view

### DIFF
--- a/modules/users/client/views/admin/users.client.view.html
+++ b/modules/users/client/views/admin/users.client.view.html
@@ -3,7 +3,6 @@
   data-ng-init="init()"
   data-ng-show="authenticated"
   class="page-wrapper users list-users"
-  oc-full-height
 >
   <div class="row">
     <div class="col-md-12">


### PR DESCRIPTION
The main div on the users admin view has a directive: `oc-full-height`.
However, I cannot find any directive file related to this.
I would vote to have this removed, provided I am not
missing the reason it is present. 

https://github.com/StetSolutions/pean/blob/master/modules/users/client/views/admin/users.client.view.html#L6
