### PR TITLE
Put the Roles text outside of font-awesome icon

### DIFF
--- a/modules/users/client/views/admin/users.client.view.html
+++ b/modules/users/client/views/admin/users.client.view.html
@@ -62,7 +62,7 @@
                         data-ng-click="openRolesModal($index, 'sm')"
                         class="btn btn-default"
                         >
-                      <i class="fa fa-plus-circle"></i> &nbsp;Roles
+                      <i class="fa fa-plus-circle"></i> Roles
                     </button>
                   </td>
                   <td

--- a/modules/users/client/views/admin/users.client.view.html
+++ b/modules/users/client/views/admin/users.client.view.html
@@ -62,7 +62,7 @@
                         data-ng-click="openRolesModal($index, 'sm')"
                         class="btn btn-default"
                         >
-                      <i class="fa fa-plus-circle"> Roles</i>
+                      <i class="fa fa-plus-circle"></i> &nbsp;Roles
                     </button>
                   </td>
                   <td


### PR DESCRIPTION
Because the Roles text inside the button which triggers the Roles modal
is inside the font-awesome icon, the Roles text gets rendered in Times New Roman (at least for me)
rather than whatever the default font is for body text as per css style sheets. 
`<i class="fa fa-plus-circle"> Roles</i>`

Please consider putting the Roles text outside of the font-awesome icon.
`<i class="fa fa-plus-circle"></i> &nbsp;Roles`

https://github.com/StetSolutions/pean/blob/4d135c9ccb992b225bffbded38ebcd920cddaca6/modules/users/client/views/admin/users.client.view.html#L65
