### PR TITLE
remove input-small on admin users

### DIFF
--- a/modules/users/client/views/admin/users.client.view.html
+++ b/modules/users/client/views/admin/users.client.view.html
@@ -103,7 +103,7 @@
                   data-ng-disabled="numberOfPages == 0"
                   data-ng-model="currentPage"
                   data-ng-model-options="{ debounce: 1000 }"
-                  class="form-control input-small"
+                  class="form-control input-sm"
                   min="1"
                   max="numberOfPages"
                   type="number"

--- a/modules/users/client/views/admin/users.client.view.html
+++ b/modules/users/client/views/admin/users.client.view.html
@@ -103,7 +103,7 @@
                   data-ng-disabled="numberOfPages == 0"
                   data-ng-model="currentPage"
                   data-ng-model-options="{ debounce: 1000 }"
-                  class="form-control input-sm"
+                  class="form-control"
                   min="1"
                   max="numberOfPages"
                   type="number"


### PR DESCRIPTION
Not sure where the "input-small" class is supposed to be coming from.
I think it should be replaced with "input-sm".
http://getbootstrap.com/css/

![image](https://cloud.githubusercontent.com/assets/2031435/12698715/a3987482-c769-11e5-8e80-167591b98690.png)

https://github.com/StetSolutions/pean/blob/dac8494601808710a2971c2cb4d11fa7e5962692/modules/users/client/views/admin/users.client.view.html#L106

I would also propose to have most of the inputs, buttons, and select elements
to use .input-sm, but that is more a matter of individual preference.
