### PR TITLE
feat(users): Fix "signin" promise return warning

### DIFF
--- a/modules/users/server/config/strategies/local.js
+++ b/modules/users/server/config/strategies/local.js
@@ -22,9 +22,11 @@ module.exports = function() {
     })
     .then(function(user) {
       if (!user || !user.authenticate(user, password)) {
-        return done(null, false, {
+        done(null, false, {
           message: 'Invalid username or password'
         });
+
+        return null;
       }
 
       done(null, user);


### PR DESCRIPTION
Silences warning when local strategy fails to return promise by returning "null".  

Fixes #24 
